### PR TITLE
feat: add galaxy tool

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -16,6 +16,7 @@ const TOOLS_ROUTES: Routes = [
     {path: "scatter", loadChildren: () => import('./tools/scatter/scatter.module').then(m => m.ScatterModule)},
     {path: "variable", loadChildren: () => import('./tools/variable/variable.module').then(m => m.VariableModule)},
     {path: "spectrum", loadChildren: () => import('./tools/spectrum/spectrum.module').then(m => m.SpectrumModule)},
+    {path: "galaxy", loadChildren: () => import('./tools/galaxy/galaxy.module').then(m => m.GalaxyModule)},
     {path: "dual", loadChildren: () => import('./tools/dual/dual.module').then(m => m.DualModule)},
     {path: "radio-calibrator", loadChildren: () => import('./tools/radioCalibrate/radioCalibrate.module').then(m => m.RadioCalibrateModule)},
     {path: "radio-source-finder", loadChildren: () => import('./tools/radiosearch/radiosearch.module').then(m => m.RadioSearchModule)},

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -25,6 +25,7 @@ import {VenusModule} from "./tools/venus/venus.module";
 import {VariableModule} from "./tools/variable/variable.module";
 import {ScatterModule} from "./tools/scatter/scatter.module";
 import {SpectrumModule} from "./tools/spectrum/spectrum.module";
+import {GalaxyModule} from "./tools/galaxy/galaxy.module";
 import {DualModule} from "./tools/dual/dual.module";
 import {RadioCalibrateModule} from "./tools/radioCalibrate/radioCalibrate.module";
 import {RadioSearchModule} from './tools/radiosearch/radiosearch.module';
@@ -58,6 +59,7 @@ registerAllModules();
         VariableModule,
         ScatterModule,
         SpectrumModule,
+        GalaxyModule,
         DualModule,
         RadioCalibrateModule,
         RadioSearchModule,

--- a/src/app/shared/home/home.component.html
+++ b/src/app/shared/home/home.component.html
@@ -141,6 +141,22 @@
                     </mat-card-content>
                 </mat-card>
             </div>
+            <div [routerLink]="'/galaxy'" class="tile-container">
+                <mat-card class="tile">
+                    <mat-card-header>
+                        <mat-card-title>Galaxy</mat-card-title>
+                        <mat-card-subtitle>MWU!</mat-card-subtitle>
+                    </mat-card-header>
+                    <div class="chart-preview">
+                        <app-galaxy-highchart></app-galaxy-highchart>
+                    </div>
+                    <mat-card-content>
+                        <p>
+                            Description for the Galaxy plotting tool goes here.
+                        </p>
+                    </mat-card-content>
+                </mat-card>
+            </div>
             <div [routerLink]="'/radio-source-finder'" class="tile-container">
                 <mat-card class="tile">
                     <mat-card-header>

--- a/src/app/shared/tools-navbar/tools-navbar.component.html
+++ b/src/app/shared/tools-navbar/tools-navbar.component.html
@@ -16,6 +16,8 @@
                routerLinkActive="active">Scatter</a>
             <a (click)="close()" [routerLink]="['/spectrum']" i18n="Spectrum" mat-list-item
                routerLinkActive="active">Spectrum</a>
+            <a (click)="close()" [routerLink]="['/galaxy']" i18n="Galaxy" mat-list-item
+               routerLinkActive="active">Galaxy</a>
             <a (click)="close()" [routerLink]="['/dual']" i18n="Dual" mat-list-item
                routerLinkActive="active">Dual</a>
             <a (click)="close()" [routerLink]="['/cluster']" i18n="Dual" mat-list-item

--- a/src/app/tools/galaxy/galaxy-chart-form/galaxy-chart-form.component.html
+++ b/src/app/tools/galaxy/galaxy-chart-form/galaxy-chart-form.component.html
@@ -1,0 +1,38 @@
+<div class="form-pop-container">
+  <form [formGroup]="formGroup">
+    <div class="row">
+      <div class="col">
+        <mat-form-field>
+          <mat-label>Title</mat-label>
+          <input [formControlName]="'chartTitle'" matInput>
+        </mat-form-field>
+      </div>
+      <div class="col">
+        <mat-form-field>
+          <mat-label>Data</mat-label>
+          <input [formControlName]="'dataLabel'" matInput
+                 placeholder="Labels for different curves are separated by comma.">
+        </mat-form-field>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col">
+        <mat-form-field>
+          <mat-label>X Axis</mat-label>
+          <input [formControlName]="'xAxisLabel'" matInput>
+        </mat-form-field>
+      </div>
+      <div class="col">
+        <mat-form-field>
+          <mat-label>Y Axis</mat-label>
+          <input [formControlName]="'yAxisLabel'" matInput>
+        </mat-form-field>
+      </div>
+    </div>
+  </form>
+  <div class="button-container">
+    <button [mat-dialog-close]="'OK'" mat-raised-button>OK</button>
+    <button (click)="resetLabels()" [color]="'warn'" mat-raised-button>Reset Graph Labels</button>
+    <button [color]="'primary'" [mat-dialog-close]="'saveGraph'" mat-raised-button>Save Graph</button>
+  </div>
+</div>

--- a/src/app/tools/galaxy/galaxy-chart-form/galaxy-chart-form.component.spec.ts
+++ b/src/app/tools/galaxy/galaxy-chart-form/galaxy-chart-form.component.spec.ts
@@ -1,0 +1,23 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+
+import {GalaxyChartFormComponent} from './galaxy-chart-form.component';
+
+describe('GalaxyChartFormComponent', () => {
+  let component: GalaxyChartFormComponent;
+  let fixture: ComponentFixture<GalaxyChartFormComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [GalaxyChartFormComponent]
+    })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(GalaxyChartFormComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/tools/galaxy/galaxy-chart-form/galaxy-chart-form.component.ts
+++ b/src/app/tools/galaxy/galaxy-chart-form/galaxy-chart-form.component.ts
@@ -1,0 +1,51 @@
+import {Component, OnDestroy} from '@angular/core';
+import {FormControl, FormGroup} from "@angular/forms";
+import {debounceTime, Subject, takeUntil} from "rxjs";
+import {GalaxyService} from "../galaxy.service";
+
+@Component({
+  selector: 'app-galaxy-chart-form',
+  templateUrl: './galaxy-chart-form.component.html',
+  styleUrls: ['./galaxy-chart-form.component.scss', '../../shared/interface/chart-form.scss']
+})
+export class GalaxyChartFormComponent implements OnDestroy {
+  formGroup!: FormGroup;
+  private destroy$: Subject<any> = new Subject<any>();
+
+  constructor(private service: GalaxyService) {
+    this.service.chartInfo$.pipe(
+      takeUntil(this.destroy$)
+    ).subscribe(info => {
+      this.formGroup = new FormGroup({
+        chartTitle: new FormControl(this.service.getChartTitle()),
+        dataLabel: new FormControl({value: this.service.getDataLabel(), disabled: true}),
+        xAxisLabel: new FormControl(this.service.getXAxisLabel()),
+        yAxisLabel: new FormControl(this.service.getYAxisLabel()),
+      })
+      this.formGroup.controls['chartTitle'].valueChanges.pipe(
+        debounceTime(200),
+      ).subscribe(title => {
+        this.service.setChartTitle(title);
+      });
+      this.formGroup.controls['xAxisLabel'].valueChanges.pipe(
+        debounceTime(200),
+      ).subscribe(label => {
+        this.service.setXAxisLabel(label);
+      });
+      this.formGroup.controls['yAxisLabel'].valueChanges.pipe(
+        debounceTime(200),
+      ).subscribe(label => {
+        this.service.setYAxisLabel(label);
+      });
+    })
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next(null);
+    this.destroy$.complete();
+  }
+
+  resetLabels() {
+    this.service.resetChartInfo();
+  }
+}

--- a/src/app/tools/galaxy/galaxy-form/galaxy-form.component.html
+++ b/src/app/tools/galaxy/galaxy-form/galaxy-form.component.html
@@ -1,0 +1,12 @@
+<div class="container">
+  <form class="h-fit">
+    <mat-form-field appearance="fill">
+      <mat-label i18n>Select a Channel</mat-label>
+      <mat-select (selectionChange)="onSelect()" [formControl]="form" name="channel">
+        <mat-option *ngFor="let channel of channelOptions" [value]="channel">
+          {{channel}}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+  </form>
+</div>

--- a/src/app/tools/galaxy/galaxy-form/galaxy-form.component.scss
+++ b/src/app/tools/galaxy/galaxy-form/galaxy-form.component.scss
@@ -1,0 +1,4 @@
+mat-form-field {
+  width: 100%;
+
+}

--- a/src/app/tools/galaxy/galaxy-form/galaxy-form.component.spec.ts
+++ b/src/app/tools/galaxy/galaxy-form/galaxy-form.component.spec.ts
@@ -1,0 +1,23 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+
+import {GalaxyFormComponent} from './galaxy-form.component';
+
+describe('GalaxyFormComponent', () => {
+  let component: GalaxyFormComponent;
+  let fixture: ComponentFixture<GalaxyFormComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [GalaxyFormComponent]
+    })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(GalaxyFormComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/tools/galaxy/galaxy-form/galaxy-form.component.ts
+++ b/src/app/tools/galaxy/galaxy-form/galaxy-form.component.ts
@@ -1,0 +1,25 @@
+import {Component} from '@angular/core';
+import {GalaxyOptions} from "../galaxy.service.util";
+import {FormControl} from "@angular/forms";
+import {GalaxyService} from "../galaxy.service";
+
+@Component({
+  selector: 'app-galaxy-form',
+  templateUrl: './galaxy-form.component.html',
+  styleUrls: ['./galaxy-form.component.scss']
+})
+export class GalaxyFormComponent {
+  form: FormControl = new FormControl({});
+  protected channelOptions = [
+    GalaxyOptions.ONE,
+    GalaxyOptions.TWO,
+  ]
+
+  constructor(private service: GalaxyService) {
+    this.form.setValue(this.service.getChannel());
+  }
+
+  onSelect() {
+    this.service.setChannel(this.form.value);
+  }
+}

--- a/src/app/tools/galaxy/galaxy-highchart/galaxy-highchart.component.html
+++ b/src/app/tools/galaxy/galaxy-highchart/galaxy-highchart.component.html
@@ -1,0 +1,12 @@
+<div class="chart-container" id="chart-container">
+  <highcharts-chart
+    (chartInstance)="chartInitialized($event)"
+    [(update)]="updateFlag"
+    [Highcharts]="Highcharts"
+    [constructorType]="chartConstructor"
+    [options]="chartOptions"
+    style="width: 100%; height: 100%; display: block;"
+  ></highcharts-chart>
+</div>
+
+

--- a/src/app/tools/galaxy/galaxy-highchart/galaxy-highchart.component.scss
+++ b/src/app/tools/galaxy/galaxy-highchart/galaxy-highchart.component.scss
@@ -1,0 +1,13 @@
+.chart-container {
+  width: 100%;
+  height: 100%;
+  padding: 10px;
+}
+
+:host ::ng-deep .highcharts-color-0 {
+  fill: var(--highcharts-background-color);
+}
+
+:host ::ng-deep .highcharts-color-1 {
+  fill: var(--highcharts-background-color);
+}

--- a/src/app/tools/galaxy/galaxy-highchart/galaxy-highchart.component.spec.ts
+++ b/src/app/tools/galaxy/galaxy-highchart/galaxy-highchart.component.spec.ts
@@ -1,0 +1,23 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+
+import {GalaxyHighchartComponent} from './galaxy-highchart.component';
+
+describe('GalaxyHighchartComponent', () => {
+  let component: GalaxyHighchartComponent;
+  let fixture: ComponentFixture<GalaxyHighchartComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [GalaxyHighchartComponent]
+    })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(GalaxyHighchartComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/tools/galaxy/galaxy-highchart/galaxy-highchart.component.ts
+++ b/src/app/tools/galaxy/galaxy-highchart/galaxy-highchart.component.ts
@@ -1,0 +1,162 @@
+import {AfterViewInit, Component, OnDestroy} from '@angular/core';
+import {Subject, takeUntil} from "rxjs";
+import * as Highcharts from "highcharts";
+
+import {GalaxyService} from "../galaxy.service";
+import {GalaxyOptions} from "../galaxy.service.util";
+
+@Component({
+  selector: 'app-galaxy-highchart',
+  templateUrl: './galaxy-highchart.component.html',
+  styleUrls: ['./galaxy-highchart.component.scss']
+})
+export class GalaxyHighchartComponent implements AfterViewInit, OnDestroy {
+  Highcharts: typeof Highcharts = Highcharts;
+  updateFlag: boolean = true;
+  chartConstructor: any = "chart";
+  chartObject!: Highcharts.Chart;
+  chartOptions: Highcharts.Options = {
+    chart: {
+      animation: false,
+      styledMode: true,
+      panning: {
+        enabled: true,
+        type: 'x',
+      },
+      panKey: 'shift',
+      zooming: {
+        type: 'x',
+      },
+    },
+    legend: {
+      align: 'center',
+    },
+    tooltip: {
+      enabled: true,
+      shared: false,
+    },
+    exporting: {
+      buttons: {
+        contextButton: {
+          enabled: false,
+        }
+      }
+    }
+  };
+  private destroy$: Subject<any> = new Subject<any>();
+
+  constructor(private service: GalaxyService) {
+    this.setChartTitle();
+    this.setChartXAxis();
+    this.setChartYAxis();
+  }
+
+  chartInitialized($event: Highcharts.Chart) {
+    this.chartObject = $event;
+    this.service.setHighChart(this.chartObject);
+
+  }
+
+  ngAfterViewInit(): void {
+    this.initChartSeries();
+    this.service.data$.pipe(
+      takeUntil(this.destroy$)
+    ).subscribe(() => {
+      this.updateData();
+      this.updateChart();
+    });
+    this.service.chartInfo$.pipe(
+      takeUntil(this.destroy$)
+    ).subscribe(() => {
+      this.setChartTitle();
+      this.setChartXAxis();
+      this.setChartYAxis();
+      this.updateChart();
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next(null);
+    this.destroy$.complete();
+  }
+
+  initChartSeries() {
+    this.setData();
+  }
+
+  setData() {
+    this.chartObject.addSeries({
+      name: GalaxyOptions.ONE,
+      data: this.service.getDataArray()[0],
+      type: 'line',
+      visible: GalaxyOptions.ONE === this.service.getChannel(),
+      showInLegend: GalaxyOptions.ONE === this.service.getChannel(),
+      marker: {
+        // only enable marker when it iss radio galaxy aka the frequency is low enough
+        enabled: this.service.getDataArray()[0][0][0] < 1000,
+        symbol: 'circle',
+        radius: 3,
+      },
+    });
+    this.chartObject.addSeries({
+      name: GalaxyOptions.TWO,
+      data: this.service.getDataArray()[1],
+      type: 'line',
+      visible: GalaxyOptions.TWO === this.service.getChannel(),
+      showInLegend: GalaxyOptions.TWO === this.service.getChannel(),
+      marker: {
+        enabled: this.service.getDataArray()[1][0][0] < 1000,
+        symbol: 'circle',
+        radius: 3,
+      },
+    });
+  }
+
+  updateData() {
+    this.chartObject.series[0].update({
+      name: GalaxyOptions.ONE,
+      data: this.service.getDataArray()[0],
+      type: 'line',
+      visible: GalaxyOptions.ONE === this.service.getChannel(),
+      showInLegend: GalaxyOptions.ONE === this.service.getChannel(),
+      marker: {
+        enabled: this.service.getDataArray()[0][0][0] < 1000,
+        symbol: 'circle',
+        radius: 3,
+      },
+    });
+    this.chartObject.series[1].update({
+      name: GalaxyOptions.TWO,
+      data: this.service.getDataArray()[1],
+      type: 'line',
+      visible: GalaxyOptions.TWO === this.service.getChannel(),
+      showInLegend: GalaxyOptions.TWO === this.service.getChannel(),
+      marker: {
+        enabled: this.service.getDataArray()[1][0][0] < 1000,
+        symbol: 'circle',
+        radius: 3,
+      },
+    });
+  }
+
+  private updateChart(): void {
+    this.updateFlag = true;
+  }
+
+  private setChartTitle(): void {
+    this.chartOptions.title = {text: this.service.getChartTitle()};
+  }
+
+  private setChartXAxis(): void {
+    this.chartOptions.xAxis = {
+      title: {text: this.service.getXAxisLabel()}
+    };
+  }
+
+  private setChartYAxis(): void {
+    this.chartOptions.yAxis = {
+      title: {text: this.service.getYAxisLabel()}
+    };
+  }
+
+}

--- a/src/app/tools/galaxy/galaxy-table/galaxy-table.component.html
+++ b/src/app/tools/galaxy/galaxy-table/galaxy-table.component.html
@@ -1,0 +1,30 @@
+<div class="container">
+  <hot-table #table
+             [afterChange]="onChange"
+             [afterCreateRow]="onInsert"
+             [allowInsertColumn]="false"
+             [allowInsertRow]="true"
+             [beforePaste]="beforePaste"
+             [beforeRemoveRow]="onRemove"
+             [colHeaders]="colNames"
+             [contextMenu]="[
+    'undo',
+    'redo',
+    'copy',
+    '---------',
+    'row_above',
+    'row_below',
+    '---------',
+    'remove_row']"
+             [data]="dataSet"
+             [hiddenColumns]="true"
+             [hotId]="id"
+             [preventOverflow]="'horizontal'"
+             [renderAllRows]="false"
+             [rowHeaders]="true"
+             [stretchH]="'all'"
+             [type]="'numeric'"
+             id="table"
+             licenseKey="non-commercial-and-evaluation">
+  </hot-table>
+</div>

--- a/src/app/tools/galaxy/galaxy-table/galaxy-table.component.scss
+++ b/src/app/tools/galaxy/galaxy-table/galaxy-table.component.scss
@@ -1,0 +1,5 @@
+.container {
+  height: 100%;
+  width: 100%;
+  overflow: hidden;
+}

--- a/src/app/tools/galaxy/galaxy-table/galaxy-table.component.spec.ts
+++ b/src/app/tools/galaxy/galaxy-table/galaxy-table.component.spec.ts
@@ -1,0 +1,23 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+
+import {GalaxyTableComponent} from './galaxy-table.component';
+
+describe('GalaxyTableComponent', () => {
+  let component: GalaxyTableComponent;
+  let fixture: ComponentFixture<GalaxyTableComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [GalaxyTableComponent]
+    })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(GalaxyTableComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/tools/galaxy/galaxy-table/galaxy-table.component.ts
+++ b/src/app/tools/galaxy/galaxy-table/galaxy-table.component.ts
@@ -1,0 +1,92 @@
+import {AfterViewInit, Component, OnDestroy} from '@angular/core';
+import {MyTable} from "../../shared/tables/table-interface";
+import {GalaxyDataDict} from "../../galaxy/galaxy.service.util";
+import {Subject, takeUntil} from "rxjs";
+import {GalaxyService} from "../../galaxy/galaxy.service";
+import {MyData} from "../../shared/data/data.interface";
+import {HotTableRegisterer} from "@handsontable/angular";
+import Handsontable from "handsontable";
+import {beforePaste} from "../../shared/tables/util";
+
+@Component({
+  selector: 'app-galaxy-table',
+  templateUrl: './galaxy-table.component.html',
+  styleUrls: ['./galaxy-table.component.scss']
+})
+export class GalaxyTableComponent implements AfterViewInit, OnDestroy {
+  id: string = "galaxy-table";
+  table: MyTable = new GalaxyTable(this.id);
+  colNames: string[] = ["Frequency", "Channel 1", "Channel 2"];
+  dataSet: GalaxyDataDict[];
+  private destroy$: Subject<void> = new Subject<void>();
+
+  constructor(private service: GalaxyService) {
+    this.dataSet = this.service.getData();
+  }
+
+  ngAfterViewInit(): void {
+    this.service.data$.pipe(
+      takeUntil(this.destroy$)
+    ).subscribe((data: MyData) => {
+      this.dataSet = this.limitPrecision(this.service.getData());
+      this.table.renderTable();
+    })
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  public onChange = (changes: any, source: any) => {
+    if (changes) {
+      this.service.setData(this.table.getData());
+    }
+  }
+
+  public onRemove = (index: number, amount: number) => {
+    this.service.removeRow(index, amount);
+  }
+
+  public onInsert = (index: number, amount: number) => {
+    this.service.addRow(index, amount);
+  }
+
+  public beforePaste = (data: any[], coords: any) => {
+    return beforePaste(data, coords, this.table);
+  }
+
+  private limitPrecision(data: GalaxyDataDict[]): GalaxyDataDict[] {
+    return data.map(
+      (row: GalaxyDataDict) => {
+        return {
+          frequency: row.frequency ? parseFloat(row.frequency.toFixed(4)) : row.frequency,
+          channel1: row.channel1 ? parseFloat(row.channel1.toFixed(2)) : row.channel1,
+          channel2: row.channel2 ? parseFloat(row.channel2.toFixed(2)) : row.channel2,
+        }
+      }
+    );
+  }
+}
+
+class GalaxyTable implements MyTable {
+  private readonly id: string;
+  private hotRegisterer = new HotTableRegisterer();
+
+  constructor(id: string) {
+    this.id = id;
+  }
+
+  getTable(): Handsontable {
+    return this.hotRegisterer.getInstance(this.id);
+  }
+
+  renderTable(): void {
+    this.getTable().render();
+  }
+
+  getData(): any[] {
+    return this.getTable().getSourceData();
+  }
+
+}

--- a/src/app/tools/galaxy/galaxy.module.ts
+++ b/src/app/tools/galaxy/galaxy.module.ts
@@ -1,0 +1,60 @@
+import {NgModule} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {GalaxyComponent} from './galaxy/galaxy.component';
+import {SimpleDataButtonModule} from "../shared/simple-data-button/simple-data-button.component";
+import {SimpleGraphButtonModule} from "../shared/simple-graph-button/simple-graph-button.component";
+import {GalaxyTableComponent} from './galaxy-table/galaxy-table.component';
+import {HotTableModule} from "@handsontable/angular";
+import {GalaxyService} from "./galaxy.service";
+import {GalaxyFormComponent} from './galaxy-form/galaxy-form.component';
+import {FormsModule, ReactiveFormsModule} from "@angular/forms";
+
+
+import {GalaxyChartFormComponent} from './galaxy-chart-form/galaxy-chart-form.component';
+
+import {GalaxyHighchartComponent} from './galaxy-highchart/galaxy-highchart.component';
+import {HighchartsChartModule} from "highcharts-angular";
+import {RouterModule, Routes} from "@angular/router";
+import {MatDialogModule} from "@angular/material/dialog";
+import {MatFormFieldModule} from "@angular/material/form-field";
+import {MatOptionModule} from "@angular/material/core";
+import {MatSelectModule} from "@angular/material/select";
+import {MatSliderModule} from "@angular/material/slider";
+import {MatInputModule} from "@angular/material/input";
+import {MatButtonModule} from "@angular/material/button";
+
+
+const routes: Routes = [
+  {path: '', component: GalaxyComponent, title: 'Galaxy'}
+];
+
+@NgModule({
+  declarations: [
+    GalaxyComponent,
+    GalaxyTableComponent,
+    GalaxyFormComponent,
+    GalaxyChartFormComponent,
+    GalaxyHighchartComponent
+  ],
+  imports: [
+    RouterModule.forChild(routes),
+    CommonModule,
+    SimpleDataButtonModule,
+    SimpleGraphButtonModule,
+    HotTableModule,
+    FormsModule,
+    MatFormFieldModule,
+    MatOptionModule,
+    MatSelectModule,
+    MatSliderModule,
+    ReactiveFormsModule,
+    MatInputModule,
+    HighchartsChartModule,
+    MatDialogModule,
+    MatButtonModule,
+  ],
+  exports: [GalaxyComponent, RouterModule, GalaxyHighchartComponent],
+  providers: [GalaxyService]
+})
+export class GalaxyModule {
+}

--- a/src/app/tools/galaxy/galaxy.service.spec.ts
+++ b/src/app/tools/galaxy/galaxy.service.spec.ts
@@ -1,0 +1,16 @@
+import {TestBed} from '@angular/core/testing';
+
+import {GalaxyService} from './galaxy.service';
+
+describe('GalaxyService', () => {
+  let service: GalaxyService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(GalaxyService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/tools/galaxy/galaxy.service.ts
+++ b/src/app/tools/galaxy/galaxy.service.ts
@@ -1,0 +1,159 @@
+import {Injectable} from '@angular/core';
+import {
+  GalaxyChartInfo,
+  GalaxyChartInfoStorageObject,
+  GalaxyData,
+  GalaxyDataDict,
+  GalaxyInterface,
+  GalaxyInterfaceImpl,
+  GalaxyOptions,
+  GalaxyStorage
+} from "./galaxy.service.util";
+import {BehaviorSubject} from "rxjs";
+import {MyData} from "../shared/data/data.interface";
+import {ChartInfo} from "../shared/charts/chart.interface";
+import * as Highcharts from "highcharts";
+
+@Injectable()
+export class GalaxyService implements MyData, GalaxyInterface, ChartInfo {
+  private galaxyData: GalaxyData = new GalaxyData();
+  private galaxyInterface: GalaxyInterfaceImpl = new GalaxyInterfaceImpl();
+  private galaxyChartInfo: GalaxyChartInfo = new GalaxyChartInfo();
+
+  private galaxyStorage: GalaxyStorage = new GalaxyStorage();
+
+  private dataSubject: BehaviorSubject<GalaxyData> = new BehaviorSubject<GalaxyData>(this.galaxyData);
+  public data$ = this.dataSubject.asObservable();
+  private interfaceSubject: BehaviorSubject<GalaxyOptions> = new BehaviorSubject<GalaxyOptions>(this.galaxyInterface.getChannel());
+  public interface$ = this.interfaceSubject.asObservable();
+  private chartInfoSubject: BehaviorSubject<GalaxyChartInfo> = new BehaviorSubject<GalaxyChartInfo>(this.galaxyChartInfo);
+  public chartInfo$ = this.chartInfoSubject.asObservable();
+
+  private highChart!: Highcharts.Chart;
+
+  constructor() {
+    this.galaxyData.setData(this.galaxyStorage.getData());
+    this.galaxyInterface.setChannel(this.galaxyStorage.getInterface());
+    this.galaxyChartInfo.setStorageObject(this.galaxyStorage.getChartInfo());
+  }
+
+
+  /** ChartInfo Methods **/
+
+  getChartTitle(): string {
+    return this.galaxyChartInfo.getChartTitle();
+  }
+
+  getDataLabel(): string {
+    return this.galaxyChartInfo.getDataLabel();
+  }
+
+  getStorageObject(): any {
+    return this.galaxyChartInfo.getStorageObject();
+  }
+
+  getXAxisLabel(): string {
+    return this.galaxyChartInfo.getXAxisLabel();
+  }
+
+  getYAxisLabel(): string {
+    return this.galaxyChartInfo.getYAxisLabel();
+  }
+
+  setChartTitle(title: string): void {
+    this.galaxyChartInfo.setChartTitle(title);
+    this.galaxyStorage.saveChartInfo(this.galaxyChartInfo.getStorageObject());
+    this.chartInfoSubject.next(this.galaxyChartInfo);
+  }
+
+  setDataLabel(data: string): void {
+    this.galaxyChartInfo.setDataLabel(data);
+    this.galaxyStorage.saveChartInfo(this.galaxyChartInfo.getStorageObject());
+    this.chartInfoSubject.next(this.galaxyChartInfo);
+    this.dataSubject.next(this.galaxyData);
+  }
+
+  setStorageObject(storageObject: GalaxyChartInfoStorageObject): void {
+    this.galaxyChartInfo.setStorageObject(storageObject);
+    this.galaxyStorage.saveChartInfo(this.galaxyChartInfo.getStorageObject());
+    this.chartInfoSubject.next(this.galaxyChartInfo);
+  }
+
+  setXAxisLabel(xAxis: string): void {
+    this.galaxyChartInfo.setXAxisLabel(xAxis);
+    this.galaxyStorage.saveChartInfo(this.galaxyChartInfo.getStorageObject());
+    this.chartInfoSubject.next(this.galaxyChartInfo);
+  }
+
+  setYAxisLabel(yAxis: string): void {
+    this.galaxyChartInfo.setYAxisLabel(yAxis);
+    this.galaxyStorage.saveChartInfo(this.galaxyChartInfo.getStorageObject());
+    this.chartInfoSubject.next(this.galaxyChartInfo);
+  }
+
+  resetChartInfo(): void {
+    this.galaxyChartInfo.setStorageObject(GalaxyChartInfo.getDefaultStorageObject());
+    this.galaxyChartInfo.setDataLabel(this.getChannel());
+    this.galaxyStorage.saveChartInfo(this.galaxyChartInfo.getStorageObject());
+    this.chartInfoSubject.next(this.galaxyChartInfo);
+  }
+
+
+  /** GalaxyInterface Methods **/
+
+  getChannel(): GalaxyOptions {
+    return this.galaxyInterface.getChannel();
+  }
+
+  setChannel(channel: GalaxyOptions): void {
+    this.galaxyInterface.setChannel(channel);
+    this.galaxyStorage.saveInterface(this.galaxyInterface.getChannel());
+    this.interfaceSubject.next(this.galaxyInterface.getChannel());
+    this.setDataLabel(this.galaxyInterface.getChannel());
+  }
+
+
+  /** MyData Methods**/
+
+
+  addRow(index: number, amount: number): void {
+    this.galaxyData.addRow(index, amount);
+    this.galaxyStorage.saveData(this.galaxyData.getData());
+    this.dataSubject.next(this.galaxyData);
+  }
+
+  getData(): GalaxyDataDict[] {
+    return this.galaxyData.getData();
+  }
+
+  getDataArray(): number[][][] {
+    return this.galaxyData.getDataArray();
+  }
+
+  removeRow(index: number, amount: number): void {
+    this.galaxyData.removeRow(index, amount);
+    this.galaxyStorage.saveData(this.galaxyData.getData());
+    this.dataSubject.next(this.galaxyData);
+  }
+
+  setData(data: GalaxyDataDict[]): void {
+    this.galaxyData.setData(data);
+    this.galaxyStorage.saveData(this.galaxyData.getData());
+    this.dataSubject.next(this.galaxyData);
+  }
+
+  resetData(): void {
+    this.galaxyData.setData(GalaxyData.getDefaultData());
+    this.galaxyStorage.saveData(this.galaxyData.getData());
+    this.dataSubject.next(this.galaxyData);
+  }
+
+  setHighChart(chart: Highcharts.Chart): void {
+    this.highChart = chart;
+  }
+
+  getHighChart(): Highcharts.Chart {
+    return this.highChart;
+  }
+
+}

--- a/src/app/tools/galaxy/galaxy.service.util.ts
+++ b/src/app/tools/galaxy/galaxy.service.util.ts
@@ -1,0 +1,242 @@
+import {MyData} from "../shared/data/data.interface";
+import {MyStorage} from "../shared/storage/storage.interface";
+import {ChartInfo} from "../shared/charts/chart.interface";
+
+export interface GalaxyDataDict {
+  frequency: number | null;
+  channel1: number | null;
+  channel2: number | null;
+}
+
+export class GalaxyData implements MyData {
+  private dataDict: GalaxyDataDict[];
+
+  constructor() {
+    this.dataDict = GalaxyData.getDefaultData();
+  }
+
+  /**
+   * Generate random data as the demo dataset
+   */
+  public static getDefaultData(): GalaxyDataDict[] {
+    const result: GalaxyDataDict[] = [];
+    for (let i = 0; i < 200; i++) {
+      const freq = i / 200 * 0.03 + 21.09;
+      result.push({
+        frequency: freq,
+        channel1: 100 - Math.pow(100 * (freq - 21.105), 2) / 0.015 + Math.random() * 21,
+        channel2: 100 - Math.pow(100 * (freq - 21.105), 2) / 0.015 + Math.random() * 21,
+      });
+    }
+    return result;
+  }
+
+  addRow(index: number, amount: number): void {
+    if (index > 0) {
+      for (let i = 0; i < amount; i++) {
+        this.dataDict.splice(index + i, 0, {frequency: null, channel1: null, channel2: null},);
+      }
+    } else {
+      this.dataDict.push({frequency: null, channel1: null, channel2: null},);
+    }
+  }
+
+  getData(): GalaxyDataDict[] {
+    return this.dataDict;
+  }
+
+  getDataArray(): number[][][] {
+    return [
+      this.dataDict.filter(
+        (galaxyDataDict: GalaxyDataDict) => {
+          return galaxyDataDict.frequency !== null
+            && galaxyDataDict.channel1 !== null;
+        }
+      ).map((entry: GalaxyDataDict) => [entry.frequency, entry.channel1]) as number[][],
+      this.dataDict.filter(
+        (galaxyDataDict: GalaxyDataDict) => {
+          return galaxyDataDict.frequency !== null
+            && galaxyDataDict.channel2 !== null;
+        }
+      ).map((entry: GalaxyDataDict) => [entry.frequency, entry.channel2]) as number[][],
+    ]
+  }
+
+  removeRow(index: number, amount: number): void {
+    this.dataDict = this.dataDict.slice(0, index).concat(this.dataDict.slice(index + amount));
+  }
+
+  setData(data: GalaxyDataDict[]): void {
+    this.dataDict = data;
+  }
+
+}
+
+
+export enum GalaxyOptions {
+  ONE = "Channel 1",
+  TWO = "Channel 2",
+}
+
+export interface GalaxyInterface {
+  getChannel(): GalaxyOptions;
+
+  setChannel(channel: GalaxyOptions): void;
+}
+
+
+export class GalaxyInterfaceImpl implements GalaxyInterface {
+  private channel: GalaxyOptions;
+
+  constructor() {
+    this.channel = GalaxyOptions.ONE;
+  }
+
+  public static getDefaultChannel(): GalaxyOptions {
+    return GalaxyOptions.ONE;
+  }
+
+  getChannel(): GalaxyOptions {
+    return this.channel;
+  }
+
+  setChannel(channel: GalaxyOptions): void {
+    this.channel = channel;
+  }
+}
+
+
+export interface GalaxyChartInfoStorageObject {
+  title: string;
+  xAxis: string;
+  yAxis: string;
+  data: string;
+}
+
+export class GalaxyChartInfo implements ChartInfo {
+  private chartTitle: string;
+  private xAxisLabel: string;
+  private yAxisLabel: string;
+  private dataLabel: string;
+
+  constructor() {
+    this.chartTitle = GalaxyChartInfo.getDefaultStorageObject().title;
+    this.xAxisLabel = GalaxyChartInfo.getDefaultStorageObject().xAxis;
+    this.yAxisLabel = GalaxyChartInfo.getDefaultStorageObject().yAxis;
+    this.dataLabel = GalaxyChartInfo.getDefaultStorageObject().data;
+  }
+
+  public static getDefaultStorageObject(): GalaxyChartInfoStorageObject {
+    return {
+      title: "Title",
+      xAxis: "",
+      yAxis: "",
+      data: "Channel 1",
+    }
+  }
+
+  getChartTitle(): string {
+    return this.chartTitle;
+  }
+
+  getDataLabel(): string {
+    return this.dataLabel;
+  }
+
+  getStorageObject(): GalaxyChartInfoStorageObject {
+    return {
+      title: this.chartTitle,
+      xAxis: this.xAxisLabel,
+      yAxis: this.yAxisLabel,
+      data: this.dataLabel,
+    }
+  }
+
+  getXAxisLabel(): string {
+    return this.xAxisLabel;
+  }
+
+  getYAxisLabel(): string {
+    return this.yAxisLabel;
+  }
+
+  setChartTitle(title: string): void {
+    this.chartTitle = title;
+  }
+
+  setDataLabel(data: string): void {
+    this.dataLabel = data;
+  }
+
+  setStorageObject(storageObject: GalaxyChartInfoStorageObject): void {
+    this.chartTitle = storageObject.title;
+    this.xAxisLabel = storageObject.xAxis;
+    this.yAxisLabel = storageObject.yAxis;
+    this.dataLabel = storageObject.data;
+  }
+
+  setXAxisLabel(xAxis: string): void {
+    this.xAxisLabel = xAxis;
+  }
+
+  setYAxisLabel(yAxis: string): void {
+    this.yAxisLabel = yAxis;
+  }
+
+}
+
+
+export class GalaxyStorage implements MyStorage {
+  private static readonly dataKey: string = 'galaxyData';
+  private static readonly interfaceKey: string = 'galaxyInterface';
+  private static readonly chartInfoKey: string = 'galaxyChartInfo';
+
+  getChartInfo(): GalaxyChartInfoStorageObject {
+    if (localStorage.getItem(GalaxyStorage.chartInfoKey)) {
+      return JSON.parse(localStorage.getItem(GalaxyStorage.chartInfoKey)!) as GalaxyChartInfoStorageObject;
+    } else {
+      return GalaxyChartInfo.getDefaultStorageObject();
+    }
+  }
+
+  getData(): GalaxyDataDict[] {
+    if (localStorage.getItem(GalaxyStorage.dataKey)) {
+      return JSON.parse(localStorage.getItem(GalaxyStorage.dataKey)!) as GalaxyDataDict[];
+    } else {
+      return GalaxyData.getDefaultData();
+    }
+  }
+
+  getInterface(): GalaxyOptions {
+    if (localStorage.getItem(GalaxyStorage.interfaceKey)) {
+      return JSON.parse(localStorage.getItem(GalaxyStorage.interfaceKey)!) as GalaxyOptions;
+    } else {
+      return GalaxyInterfaceImpl.getDefaultChannel();
+    }
+  }
+
+  resetChartInfo(): void {
+    localStorage.setItem(GalaxyStorage.chartInfoKey, JSON.stringify(GalaxyChartInfo.getDefaultStorageObject()));
+  }
+
+  resetData(): void {
+    localStorage.setItem(GalaxyStorage.dataKey, JSON.stringify(GalaxyData.getDefaultData()));
+  }
+
+  resetInterface(): void {
+    localStorage.setItem(GalaxyStorage.interfaceKey, JSON.stringify(GalaxyInterfaceImpl.getDefaultChannel()));
+  }
+
+  saveChartInfo(chartInfo: GalaxyChartInfoStorageObject): void {
+    localStorage.setItem(GalaxyStorage.chartInfoKey, JSON.stringify(chartInfo));
+  }
+
+  saveData(data: GalaxyDataDict[]): void {
+    localStorage.setItem(GalaxyStorage.dataKey, JSON.stringify(data));
+  }
+
+  saveInterface(interfaceInfo: GalaxyOptions): void {
+    localStorage.setItem(GalaxyStorage.interfaceKey, JSON.stringify(interfaceInfo));
+  }
+
+}

--- a/src/app/tools/galaxy/galaxy/galaxy.component.html
+++ b/src/app/tools/galaxy/galaxy/galaxy.component.html
@@ -1,0 +1,28 @@
+<div class="row tool-container">
+  <div class="col-4">
+    <div class="row">
+      <app-galaxy-form></app-galaxy-form>
+    </div>
+    <div class="row dynamic">
+      <app-galaxy-table></app-galaxy-table>
+    </div>
+    <div class="row button-row">
+      <app-simple-data-button (fileUpload$)="uploadHandler($event)"
+                              (tableUserActionObs$)="actionHandler($event)"
+                              [isDataRandom]="true" [isUploadData]="true">
+      </app-simple-data-button>
+    </div>
+  </div>
+  <div class="col-8">
+    <div class="row dynamic">
+      <app-galaxy-highchart></app-galaxy-highchart>
+    </div>
+    <div class="row button-row">
+      <!--      <div class="col-6">-->
+      <app-simple-graph-button (chartUserActionObs$)="actionHandler($event)" [isEditChartInfo]="true">
+      </app-simple-graph-button>
+      <!--      </div>-->
+      <!--      <div class="col-6">Click and drag to zoom. Hold down the shift key to drag and pan.</div>-->
+    </div>
+  </div>
+</div>

--- a/src/app/tools/galaxy/galaxy/galaxy.component.spec.ts
+++ b/src/app/tools/galaxy/galaxy/galaxy.component.spec.ts
@@ -1,0 +1,23 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+
+import {GalaxyComponent} from './galaxy.component';
+
+describe('GalaxyComponent', () => {
+  let component: GalaxyComponent;
+  let fixture: ComponentFixture<GalaxyComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [GalaxyComponent]
+    })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(GalaxyComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/tools/galaxy/galaxy/galaxy.component.ts
+++ b/src/app/tools/galaxy/galaxy/galaxy.component.ts
@@ -1,0 +1,130 @@
+import {Component, OnDestroy} from '@angular/core';
+import {ChartAction} from "../../shared/types/actions";
+import {HonorCodePopupService} from "../../shared/honor-code-popup/honor-code-popup.service";
+import {GalaxyService} from "../galaxy.service";
+import {HonorCodeChartService} from "../../shared/honor-code-popup/honor-code-chart.service";
+import {MyFileParser} from "../../shared/data/FileParser/FileParser";
+import {Subject, takeUntil} from "rxjs";
+import {GalaxyDataDict} from "../galaxy.service.util";
+import {FileType} from "../../shared/data/FileParser/FileParser.util";
+import {MatDialog} from "@angular/material/dialog";
+import {GalaxyChartFormComponent} from "../galaxy-chart-form/galaxy-chart-form.component";
+
+@Component({
+  selector: 'app-galaxy',
+  templateUrl: './galaxy.component.html',
+  styleUrls: ['./galaxy.component.scss', "../../shared/interface/tools.scss"]
+})
+export class GalaxyComponent implements OnDestroy {
+  private static readonly RadioTxtFields: string[] = ["Freq1(MHz)", "XX1", "YY1"];
+  private static readonly OpticalTxtFields: string[] = ["Freq1", "XX1", "YY1"];
+  private radioFileParser: MyFileParser
+    = new MyFileParser(FileType.TXT,
+    GalaxyComponent.RadioTxtFields,
+    [{key: "Actual_FREQ1"}],);
+  private opticalFileParser: MyFileParser
+    = new MyFileParser(FileType.TXT,
+    GalaxyComponent.OpticalTxtFields);
+  private destroy$: Subject<void> = new Subject<void>();
+
+  constructor(
+    private service: GalaxyService,
+    private honorCodeService: HonorCodePopupService,
+    private chartService: HonorCodeChartService,
+    private dialog: MatDialog) {
+    this.radioFileParser.error$.pipe(
+      takeUntil(this.destroy$)
+    ).subscribe(
+      (error: any) => {
+        //TODO: better error handling/displaying
+        alert("error " + error);
+      }
+    );
+    this.radioFileParser.data$.pipe(
+      takeUntil(this.destroy$)
+    ).subscribe(
+      (data: any[]) => {
+        this.service.setData(
+          rawDataToDataDict(data, GalaxyComponent.RadioTxtFields)
+        );
+      }
+    );
+    this.opticalFileParser.error$.pipe(
+      takeUntil(this.destroy$)
+    ).subscribe(
+      (error: any) => {
+        alert("error " + error);
+      });
+    this.opticalFileParser.data$.pipe(
+      takeUntil(this.destroy$)
+    ).subscribe(
+      (data: any[]) => {
+        this.service.setData(
+          rawDataToDataDict(data, GalaxyComponent.OpticalTxtFields)
+        );
+      });
+  }
+
+  actionHandler(actions: ChartAction[]) {
+    actions.forEach((action) => {
+      if (action.action === "addRow") {
+        this.service.addRow(-1, 1);
+      } else if (action.action === "saveGraph") {
+        this.saveGraph();
+      } else if (action.action === "resetData") {
+        this.service.resetData();
+      } else if (action.action === "editChartInfo") {
+        const dialogRef =
+          this.dialog.open(GalaxyChartFormComponent, {width: 'fit-content'});
+        dialogRef.afterClosed().pipe().subscribe(result => {
+          if (result === "saveGraph")
+            this.saveGraph();
+        });
+      }
+    })
+  }
+
+  uploadHandler($event: File) {
+    this.radioFileParser.getHeaders($event, false,
+      (headers, errorSubject) => {
+        if (headers && Object.keys(headers).includes("Actual_FREQ1")) {
+          this.radioFileParser.readFile($event, true);
+        } else {
+          this.opticalFileParser.readFile($event, true);
+        }
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  private saveGraph() {
+    this.honorCodeService.honored().subscribe((name: string) => {
+      this.chartService.saveImageHighChartOffline(this.service.getHighChart(), "galaxy", name);
+    });
+  }
+}
+
+function rawDataToDataDict(data: any[], fields: string[]): GalaxyDataDict[] {
+  const dataDictArray: GalaxyDataDict[] = [];
+  const freqArray: number[] = [];
+  data.forEach((rawData: any) => {
+    const freq = parseFloat(rawData[fields[0]]);
+    const channel1 = parseFloat(rawData[fields[1]]);
+    const channel2 = parseFloat(rawData[fields[2]]);
+    if (!isNaN(freq) && !isNaN(channel1)) {
+      freqArray.push(freq);
+      dataDictArray.push({
+        frequency: freq,
+        channel1: isNaN(channel1) ? null : channel1,
+        channel2: isNaN(channel2) ? null : channel2,
+      });
+    }
+  });
+  const freqRange = freqArray.length ? [Math.min(...freqArray), Math.max(...freqArray)] : [0, 0];
+  // freqRange currently unused but retained for future adjustments
+  return dataDictArray.length > 0 ? dataDictArray : [{frequency: null, channel1: null, channel2: null}];
+}
+


### PR DESCRIPTION
## Summary
- add Galaxy plotting tool modeled after Spectrum
- show Galaxy on MWU! home tab and in sidebar
- register Galaxy module and routing

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68c0791957b883308eea276f920c90d2